### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/base/api/views.py
+++ b/base/api/views.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.decorators import api_view
 import logging
+import traceback
 from .Ridwaanhall import DATABASE_API, DATABASE
 
 def getRoutes(request):
@@ -1336,7 +1337,8 @@ class HasilRekap(APIView):
             data = response.json()
             return Response(data)
         except Exception as e:
-            return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            logging.error("Exception occurred", exc_info=True)
+            return Response({'error': 'An internal error has occurred!'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         
         
 class HasilRekap1API(APIView):


### PR DESCRIPTION
Potential fix for [https://github.com/ridwaanhall/realcount-pemilu-2024/security/code-scanning/5](https://github.com/ridwaanhall/realcount-pemilu-2024/security/code-scanning/5)

To fix the problem, we need to ensure that detailed error information is not exposed to the user. Instead, we should log the error on the server and return a generic error message to the user. This can be achieved by using Python's `logging` module to log the exception details and returning a generic error message in the response.

1. Import the `traceback` module to capture the stack trace.
2. Use the `logging` module to log the stack trace.
3. Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
